### PR TITLE
#44 xen-enforce-bot fails

### DIFF
--- a/Xen-Enforce-Bot/webui/index.html
+++ b/Xen-Enforce-Bot/webui/index.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" type="text/css" href="css/xga.nav.css">
     <!-- Bootstrap core CSS -->
     <!-- Custom fonts for this template -->
-    <script src="http://code.jquery.com/jquery-1.7.2.js"></script>
+    <script src="https://code.jquery.com/jquery-1.7.2.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Catamaran:100,200,300,400,500,600,700,800,900" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i" rel="stylesheet">
     <script src="https://www.google.com/recaptcha/api.js"></script>
@@ -16,7 +16,7 @@
 <body onload="">
 <center>
     <div class="w3-display-middle w3-text-white">
-        <img src="/xen-enforce-bot/xenflogo.png" class="w3-animate-top" height="150" width="150">
+        <img src="xenflogo.png" class="w3-animate-top" height="150" width="150">
         <h1 class="w3-jumbo w3-animate-top">XenEnforceBot</h1>
         <p class="w3-center">XenEnforceBot protects your telegram groups against bots and other kinds of trouble.</p>
 

--- a/Xen-Enforce-Bot/webui/verify/index.php
+++ b/Xen-Enforce-Bot/webui/verify/index.php
@@ -58,10 +58,10 @@ die();
 
 
 			<!-- Custom fonts for this template -->
-		<script src="http://code.jquery.com/jquery-1.7.2.js"></script>
+		<script src="https://code.jquery.com/jquery-1.7.2.js"></script>
 		<link href="https://fonts.googleapis.com/css?family=Catamaran:100,200,300,400,500,600,700,800,900" rel="stylesheet">
 		<link href="https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i" rel="stylesheet">
-		<script src='https://www.hCaptcha.com/1/api.js' async defer></script>
+		<script src='https://js.hcaptcha.com/1/api.js' async defer></script>
 		<link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
 		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway">
 		<meta name="viewport" content="height=device-height initial-scale=1.0">

--- a/Xen-Enforce-Bot/webui/verify/verify.php
+++ b/Xen-Enforce-Bot/webui/verify/verify.php
@@ -33,8 +33,33 @@
 
  if(isset($_POST['h-captcha-response']) && !empty($_POST['h-captcha-response']))
   {
-        $verifyResponse = file_get_contents('https://hcaptcha.com/siteverify?secret='.$secret.'&response='.$_POST['h-captcha-response'].'&remoteip='.$_SERVER['REMOTE_ADDR']);
-        $responseData = json_decode($verifyResponse);
+		$url = "https://api.hcaptcha.com/siteverify";
+
+		$curl = curl_init($url);
+		curl_setopt($curl, CURLOPT_URL, $url);
+		curl_setopt($curl, CURLOPT_POST, true);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		
+		$headers = array(
+			"Content-Type: application/x-www-form-urlencoded",
+		);
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+		
+		$data = 'secret='.$secret.'&response='.$_POST['h-captcha-response'].'&remoteip='.$_SERVER['REMOTE_ADDR'];
+
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+		
+		$verifyResponse = curl_exec($curl);
+
+		if($verifyResponse === false)
+		{
+			echo 'Curl error: ' . curl_error($curl);
+			die();
+		}
+
+
+		$responseData = json_decode($verifyResponse);
+		curl_close($curl);
         if($responseData->success == false)
         {
             header('Location: ./index.php' . "?success=0&reason=Recaptcha validation failed&actid=$actid");


### PR DESCRIPTION
This PR updates the code to conform with the updated h-captcha API standards.

I've verified these changes work in our production deployment and have tried to capture changes here.

This change closes: https://taiga.ncanthros.net/project/ncas-information-technology/issue/44

Changes:

- Updates several urls to use https instead of http
- Updates the call to `siteverify` to a POST vs a GET request
- Adds some basic error handling to the `siteverify` post request